### PR TITLE
fix(sandbox): meet secure-sandbox-policy contract in SandboxTemplate

### DIFF
--- a/a2a-with-gke-sandbox/README.md
+++ b/a2a-with-gke-sandbox/README.md
@@ -346,6 +346,17 @@ none of it is a knock on any product; it's just where the edges are today (mid-2
 
 **GKE Agent Sandbox / runtime**
 
+- **The managed addon enforces a hardened-sandbox admission policy (≥ v1.35.6).** A GKE upgrade
+  of the `agentsandbox` addon ships a `secure-sandbox-policy` ValidatingAdmissionPolicy that
+  *denies* any Sandbox not meeting a full security contract — `runtimeClassName: gvisor`,
+  `runAsNonRoot: true`, container `capabilities.drop: ["ALL"]`, gVisor `nodeSelector` +
+  toleration, resource limits, `automountServiceAccountToken: false`, etc. If the `SandboxTemplate`
+  is missing any of these, the claim never resolves (`Could not resolve sandbox name … within 180
+  seconds`), `run_code` retries to the Cloud Run 300s limit, and requests 504. The symptom looks
+  like "suddenly slow" because it's triggered by an *automatic addon upgrade*, not a code change.
+  The policy is addon-managed (`addonmanager.kubernetes.io/mode: Reconcile`) so you can't delete
+  it — the template must comply (see `deployment/bootstrap/sandbox-template.yaml`). Inspect the
+  live rules with `kubectl get validatingadmissionpolicy secure-sandbox-policy -o yaml`.
 - **Private nodes can't pull from `registry.k8s.io`.** The stock sandbox runtime image times out
   on a private cluster, so we **build our own analytics runtime** (uv + pandas/numpy/matplotlib/…)
   into Artifact Registry and point the `SandboxTemplate` at it.

--- a/a2a-with-gke-sandbox/deployment/bootstrap/sandbox-template.yaml
+++ b/a2a-with-gke-sandbox/deployment/bootstrap/sandbox-template.yaml
@@ -8,10 +8,24 @@ metadata:
 spec:
   podTemplate:
     spec:
-      # Untrusted code runs here — don't mount the namespace default ServiceAccount token.
-      automountServiceAccountToken: false
+      # The cluster's GKE-managed secure-sandbox-policy (ValidatingAdmissionPolicy, shipped by the
+      # agentsandbox addon) denies any Sandbox that doesn't meet this hardened contract — without it
+      # the claim never resolves and run_code times out. All of the following are required by it.
+      runtimeClassName: gvisor          # must run under gVisor
+      automountServiceAccountToken: false  # no K8s API access from untrusted code
+      securityContext:
+        runAsNonRoot: true              # image already runs as USER 1000
+      nodeSelector:
+        sandbox.gke.io/runtime: gvisor  # schedule onto gVisor nodes
+      tolerations:
+      - key: sandbox.gke.io/runtime     # tolerate the gVisor node taint
+        value: gvisor
+        effect: NoSchedule
       containers:
       - name: python-runtime
+        securityContext:
+          capabilities:
+            drop: ["ALL"]               # drop all Linux capabilities
         # Our analytics runtime, built + pushed to Artifact Registry by bootstrap.sh from
         # deployment/sandbox-runtime/ (private nodes pull from AR via Private Google Access).
         image: ${SANDBOX_IMAGE}


### PR DESCRIPTION
GKE auto-upgraded the managed agentsandbox addon (v1.35.6), which ships a secure-sandbox-policy ValidatingAdmissionPolicy enforcing a hardened-sandbox contract. The existing SandboxTemplate only set runtimeClassName implicitly and automountServiceAccountToken, so every Sandbox was denied at admission — claims never resolved (180s timeout), run_code retried to the Cloud Run 300s limit, and requests 504'd. Presented as a sudden slowdown with no code change.

Add the fields the policy requires: runtimeClassName: gvisor, pod runAsNonRoot: true (image already runs as USER 1000), container capabilities.drop ["ALL"], and the gVisor nodeSelector + toleration. Document the addon-policy gotcha in the README. Verified e2e against the deployed service.