### PR TITLE
chore(cloud-run): restrict ingress to internal-only

### DIFF
--- a/a2a-with-gke-sandbox/deployment/terraform/single-project/service.tf
+++ b/a2a-with-gke-sandbox/deployment/terraform/single-project/service.tf
@@ -18,7 +18,7 @@ resource "google_cloud_run_v2_service" "app" {
   location            = var.region
   project             = var.project_id
   deletion_protection = false
-  ingress             = "INGRESS_TRAFFIC_ALL"
+  ingress             = "INGRESS_TRAFFIC_INTERNAL_ONLY"
   labels = {
     "created-by" = "adk"
   }


### PR DESCRIPTION
Gemini Enterprise reaches the agent over Google's internal backbone (same project), so INGRESS_TRAFFIC_INTERNAL_ONLY keeps GE working while dropping public-internet traffic before it hits the app. Applied to the live service. Note: the README §5 curl test from outside the VPC now returns 404.