### PR TITLE
fix(upload): strip over-cap uploads from the A2A message, not just th…

### DIFF
--- a/a2a-with-gke-sandbox/README.md
+++ b/a2a-with-gke-sandbox/README.md
@@ -335,6 +335,17 @@ none of it is a knock on any product; it's just where the edges are today (mid-2
 - **`conversation_id` == A2A `contextId` == ADK `session_id`** — all the same string (ADK sets
   `session_id = request.context_id`), and GE keeps one across a conversation's turns. So it's the
   natural, stable key for per-conversation storage (and the grouping key in the BigQuery view).
+- **An over-size upload must be stripped from the *incoming message*, not just the model call.**
+  A big inline file (a 20 MB video → ~26 MB base64 request) hangs/500s in three stacked ways:
+  (1) the a2a SDK's default 10 MB `max_content_length` rejects the request with `-32600` *before*
+  the agent runs (GE shows a spinner) — raise it to Cloud Run's ~32 MB ceiling on
+  `A2AFastAPIApplication`; (2) a2a's `TaskManager` seeds `task.history` with the *incoming message
+  object* and echoes it in the response, so the blob blows past Cloud Run's ~32 MB **response**
+  limit ("Response size was too large") and 500s no matter what the executor emits — strip the
+  over-cap `FilePart`s from `context.message` **in place at the top of `_handle_request`, before
+  enqueuing any event** (`app/a2ui_support.py:_strip_oversized_parts`); (3) GE only renders a
+  *completed* task's artifact, so surface "file too large" as a final artifact, not a protocol
+  error. Cap: `MAX_UPLOAD_BYTES` (5 MB).
 
 **Registering with Gemini Enterprise**
 

--- a/a2a-with-gke-sandbox/app/a2ui_support.py
+++ b/a2a-with-gke-sandbox/app/a2ui_support.py
@@ -32,15 +32,32 @@ logger = logging.getLogger(__name__)
 if not hasattr(builtins, "models"):
     builtins.models = _adk_models
 
-from datetime import datetime, timezone  # noqa: E402
+from datetime import UTC, datetime  # noqa: E402
 
 from a2a.types import (  # noqa: E402
     AgentExtension,
     Artifact,
+    Part,
     TaskArtifactUpdateEvent,
     TaskState,
     TaskStatus,
     TaskStatusUpdateEvent,
+    TextPart,
+)
+from a2ui.a2a.extension import get_a2ui_agent_extension  # noqa: E402
+from a2ui.adk.a2a.part_converter import A2uiPartConverter  # noqa: E402
+from a2ui.adk.send_a2ui_to_client_toolset import (  # noqa: E402
+    SendA2uiToClientToolset,
+)
+from a2ui.basic_catalog.provider import BasicCatalog  # noqa: E402
+from a2ui.schema.common_modifiers import remove_strict_validation  # noqa: E402
+from a2ui.schema.constants import (  # noqa: E402
+    A2UI_TOOL_NAME,
+    VERSION_0_8,
+)
+from a2ui.schema.manager import A2uiSchemaManager  # noqa: E402
+from google.adk.a2a.converters.event_converter import (  # noqa: E402
+    convert_event_to_a2a_events,
 )
 from google.adk.a2a.converters.utils import _get_adk_metadata_key  # noqa: E402
 from google.adk.a2a.executor.a2a_agent_executor import (  # noqa: E402
@@ -62,26 +79,42 @@ from google.adk.platform import time as platform_time  # noqa: E402
 from google.adk.platform import uuid as platform_uuid  # noqa: E402
 from google.adk.utils.context_utils import Aclosing  # noqa: E402
 
-from google.adk.a2a.converters.event_converter import (  # noqa: E402
-    convert_event_to_a2a_events,
-)
-
-from a2ui.a2a.extension import get_a2ui_agent_extension  # noqa: E402
-from a2ui.adk.a2a.part_converter import A2uiPartConverter  # noqa: E402
-from a2ui.adk.send_a2ui_to_client_toolset import (  # noqa: E402
-    SendA2uiToClientToolset,
-)
-from a2ui.schema.constants import A2UI_TOOL_NAME  # noqa: E402
-from a2ui.basic_catalog.provider import BasicCatalog  # noqa: E402
-from a2ui.schema.common_modifiers import remove_strict_validation  # noqa: E402
-from a2ui.schema.constants import VERSION_0_8  # noqa: E402
-from a2ui.schema.manager import A2uiSchemaManager  # noqa: E402
-
 _ENABLED_KEY = "system:a2ui_enabled"
 _CATALOG_KEY = "system:a2ui_catalog"  # must match A2uiEventConverter's default catalog_key
 # Maps short placeholder tokens (e.g. "{{chart:ab12}}") -> real signed URLs. run_code writes
 # this; the event converter substitutes after the LLM so the model never transcribes the URL.
 URL_MAP_KEY = "a2ui_url_map"
+
+# Per-file cap on uploads. Enforced in the executor (_handle_request) *before* the model runs:
+# an over-cap inline file must never reach the model or get echoed back, since a multi-MB blob in
+# the A2A response makes it oversize and 500s. agent.py imports this for its own skip guard.
+MAX_UPLOAD_BYTES = 5 * 1024 * 1024
+
+
+def _strip_oversized_parts(message) -> list[tuple[str, int]]:
+    """Drop over-cap inline file parts from an incoming A2A message, in place.
+
+    Returns [(name, nbytes)] for what was removed. The incoming parts are a2a FileParts with
+    base64 `bytes`; an over-cap blob must be removed *before the framework stores the message*,
+    because a2a seeds the Task's history with this same object and echoes it in the response — a
+    multi-MB blob there blows past Cloud Run's response limit and 500s. Mutating in place (the
+    Task history holds the same reference) keeps it out of both the response and the model call.
+    """
+    removed: list[tuple[str, int]] = []
+    kept = []
+    for part in getattr(message, "parts", None) or []:
+        file = getattr(getattr(part, "root", None), "file", None)
+        b64 = getattr(file, "bytes", None) if file else None
+        if b64:
+            nbytes = (len(b64) * 3) // 4  # approx decoded size of the base64 payload
+            if nbytes > MAX_UPLOAD_BYTES:
+                removed.append((getattr(file, "name", None) or "upload", nbytes))
+                continue
+        kept.append(part)
+    if removed:
+        message.parts = kept
+    return removed
+
 
 # v0.8 schema manager over the bundled standard catalog (Image, Text, Card, ...).
 _schema_manager = A2uiSchemaManager(
@@ -163,7 +196,7 @@ def _uniquify_surface_ids(a2ui_json: str) -> str:
     """
     try:
         data = json.loads(a2ui_json)
-    except Exception:  # noqa: BLE001 - not valid JSON: leave it for the tool to validate/reject
+    except Exception:
         return a2ui_json
     suffix = uuid.uuid4().hex[:8]
     mapping: dict[str, str] = {}
@@ -223,7 +256,7 @@ class _A2uiEventConverter:
 
 
 def _now_iso() -> str:
-    return datetime.fromtimestamp(platform_time.get_time(), tz=timezone.utc).isoformat()
+    return datetime.fromtimestamp(platform_time.get_time(), tz=UTC).isoformat()
 
 
 class A2uiAgentExecutor(A2aAgentExecutor):
@@ -252,8 +285,50 @@ class A2uiAgentExecutor(A2aAgentExecutor):
             use_legacy=True,
         )
 
-    async def _handle_request(self, context, event_queue):  # noqa: C901 - mirrors ADK's flow
+    async def _handle_request(self, context, event_queue):
         runner = await self._resolve_runner()
+
+        # Reject over-cap uploads up front — BEFORE building the run request or enqueuing any event
+        # (the framework seeds the Task history from this same message object). Strip the blob so it
+        # never reaches the model or the response, then emit the "too large" text as the completed
+        # task's artifact — the path GE renders — so the user sees a message, not a hung spinner.
+        oversized = _strip_oversized_parts(context.message)
+        if oversized:
+            limit_mb = MAX_UPLOAD_BYTES // (1024 * 1024)
+            listed = ", ".join(f"{n} ({sz / (1024 * 1024):.1f} MB)" for n, sz in oversized)
+            text = (
+                f"⚠️ That file is too large to process ({listed}). The limit is {limit_mb} MB "
+                f"per file — please upload a smaller file and try again."
+            )
+            await event_queue.enqueue_event(
+                TaskStatusUpdateEvent(
+                    task_id=context.task_id,
+                    context_id=context.context_id,
+                    final=False,
+                    status=TaskStatus(state=TaskState.working, timestamp=_now_iso()),
+                )
+            )
+            await event_queue.enqueue_event(
+                TaskArtifactUpdateEvent(
+                    task_id=context.task_id,
+                    context_id=context.context_id,
+                    last_chunk=True,
+                    artifact=Artifact(
+                        artifact_id=platform_uuid.new_uuid(),
+                        parts=[Part(root=TextPart(text=text))],
+                    ),
+                )
+            )
+            await event_queue.enqueue_event(
+                TaskStatusUpdateEvent(
+                    task_id=context.task_id,
+                    context_id=context.context_id,
+                    final=True,
+                    status=TaskStatus(state=TaskState.completed, timestamp=_now_iso()),
+                )
+            )
+            return
+
         run_request = self._config.request_converter(context, self._config.a2a_part_converter)
         executor_context = ExecutorContext(
             app_name=runner.app_name,

--- a/a2a-with-gke-sandbox/app/agent.py
+++ b/a2a-with-gke-sandbox/app/agent.py
@@ -26,6 +26,7 @@ from google.adk.tools.skill_toolset import SkillToolset
 from google.genai import types
 
 from app.a2ui_support import (
+    MAX_UPLOAD_BYTES,
     URL_MAP_KEY,
     build_a2ui_toolset,
     setup_a2ui_state,
@@ -49,31 +50,23 @@ os.environ["GOOGLE_CLOUD_LOCATION"] = "global"
 os.environ["GOOGLE_GENAI_USE_VERTEXAI"] = "True"
 
 
-# Per-file cap on uploads pushed into the sandbox (A2A inline bytes are base64 in the
-# request, so they're already bounded; this guards against shipping very large blobs).
-_MAX_UPLOAD_BYTES = 5 * 1024 * 1024
-
-
 def _part_filename(index, blob) -> str:
     return getattr(blob, "display_name", None) or f"upload_{index}"
 
 
 def _uploaded_files(content) -> list[tuple[str, bytes]]:
-    """Return (name, bytes) for each inline_data file in a user Content.
+    """Return (name, bytes) for each within-cap inline_data file in a user Content.
 
-    Raises ValueError if any file exceeds the size cap.
+    Over-cap uploads are rejected upstream in the A2A executor (a2ui_support) before the model
+    runs, so they never get here; we skip any that slip through (e.g. a rehydrated file) rather
+    than raise, so a single bad file can't crash the run.
     """
     out: list[tuple[str, bytes]] = []
     for i, part in enumerate((content.parts if content else None) or []):
         blob = getattr(part, "inline_data", None)
         data = getattr(blob, "data", None) if blob else None
-        if not data:
+        if not data or len(data) > MAX_UPLOAD_BYTES:
             continue
-        if len(data) > _MAX_UPLOAD_BYTES:
-            raise ValueError(
-                f"uploaded file {_part_filename(i, blob)!r} exceeds "
-                f"{_MAX_UPLOAD_BYTES} bytes"
-            )
         out.append((_part_filename(i, blob), data))
     return out
 

--- a/a2a-with-gke-sandbox/app/fast_api_app.py
+++ b/a2a-with-gke-sandbox/app/fast_api_app.py
@@ -94,7 +94,15 @@ async def build_dynamic_agent_card() -> AgentCard:
 @asynccontextmanager
 async def lifespan(app_instance: FastAPI) -> AsyncIterator[None]:
     agent_card = await build_dynamic_agent_card()
-    a2a_app = A2AFastAPIApplication(agent_card=agent_card, http_handler=request_handler)
+    # The a2a SDK defaults to a 10 MB request cap and rejects larger payloads at the transport
+    # layer with JSON-RPC -32600 *before* the agent runs — GE doesn't surface that, so the upload
+    # just hangs. Raise it to Cloud Run's ~32 MB request ceiling so over-limit uploads reach the
+    # agent, which then replies with a clear "file too large" message (see app/agent.py).
+    a2a_app = A2AFastAPIApplication(
+        agent_card=agent_card,
+        http_handler=request_handler,
+        max_content_length=32 * 1024 * 1024,
+    )
     a2a_app.add_routes_to_app(
         app_instance,
         agent_card_url=f"{A2A_RPC_PATH}{AGENT_CARD_WELL_KNOWN_PATH}",

--- a/a2a-with-gke-sandbox/tests/sandbox/test_strip_part_metadata.py
+++ b/a2a-with-gke-sandbox/tests/sandbox/test_strip_part_metadata.py
@@ -1,6 +1,11 @@
-from google.genai import types
-from google.adk.models.llm_request import LlmRequest
+import base64
 
+from a2a.types import FilePart, FileWithBytes, Message, Role, TextPart
+from a2a.types import Part as A2APart
+from google.adk.models.llm_request import LlmRequest
+from google.genai import types
+
+from app.a2ui_support import MAX_UPLOAD_BYTES, _strip_oversized_parts
 from app.agent import _before_model
 
 
@@ -29,3 +34,27 @@ def test_advertises_uploaded_filenames():
     )
     assert _before_model(None, req) is None
     assert "data.csv" in str(req.config.system_instruction)
+
+
+def _a2a_file_part(nbytes: int, name: str) -> A2APart:
+    b64 = base64.b64encode(b"x" * nbytes).decode()
+    return A2APart(root=FilePart(file=FileWithBytes(bytes=b64, mime_type="video/mp4", name=name)))
+
+
+def test_strip_oversized_removes_blob_and_reports_it():
+    # The executor strips over-cap file parts IN PLACE before the message is stored, so the blob
+    # never lands in the Task history (echoed in the response) or reaches the model.
+    text = A2APart(root=TextPart(text="analyse this"))
+    big = _a2a_file_part(MAX_UPLOAD_BYTES + 1024, "clip.mp4")
+    msg = Message(message_id="m1", role=Role.user, parts=[text, big])
+
+    removed = _strip_oversized_parts(msg)
+    assert [n for n, _ in removed] == ["clip.mp4"]
+    assert msg.parts == [text]  # text kept, oversized blob gone
+
+
+def test_strip_keeps_within_cap_files():
+    small = _a2a_file_part(1024, "data.csv")
+    msg = Message(message_id="m2", role=Role.user, parts=[small])
+    assert _strip_oversized_parts(msg) == []
+    assert msg.parts == [small]


### PR DESCRIPTION
…e model call

An over-limit upload hung the Gemini Enterprise spinner / 500'd. The cause was layered and the first attempts only peeled off the outer layers:
- the a2a SDK's 10 MB max_content_length rejected the request at the transport layer (-32600) before the agent ran, which GE shows as a hang; and
- once the request was let through, the multi-MB inline blob was echoed back in the response because a2a's TaskManager seeds the Task history with the incoming message object (_init_task_obj: history = [initial_message]) and returns it — so the response exceeded Cloud Run's ~32 MB limit ("Response size was too large") and 500'd, no matter what the executor emitted.

Fix at the real source:
- fast_api_app: raise max_content_length to 32 MB so the request reaches the app.
- a2ui_support: at the very top of _handle_request, _strip_oversized_parts() removes over-cap a2a FileParts from context.message IN PLACE (the same object the Task history references) BEFORE building the run request or enqueuing any event, then short-circuits with the "file too large" text as the completed task's artifact (the path GE renders). Blob never reaches history, response, or the model.
- agent: cap moved to a2ui_support (MAX_UPLOAD_BYTES); _uploaded_files skips, not raises, on any over-cap file that slips through.
- test: oversized a2a file part is stripped + reported; within-cap is kept.

Verified: 31 sandbox tests pass, lint clean.